### PR TITLE
surya: enable encryption this being a Vanilla build

### DIFF
--- a/aosp_surya.mk
+++ b/aosp_surya.mk
@@ -15,8 +15,6 @@ $(call inherit-product, device/xiaomi/surya/device.mk)
 $(call inherit-product, vendor/aosp/common.mk)
 
 EXTENDED_BUILD_TYPE := OFFICIAL
-WITH_GAPPS := true
-TARGET_GAPPS_ARCH := arm64
 IS_PHONE := true
 
 PRODUCT_NAME := aosp_surya

--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -42,7 +42,7 @@ vendor                                                            /vendor       
 /dev/block/by-name/metadata                                       /metadata            ext4    noatime,nosuid,nodev,discard                                                                    wait,formattable,wrappedkey,first_stage_mount
 
 # Add fs_mgr flag - sysfs_path=/sys/devices/platform/soc/xxxx.[ufshc|sdhci] to userdata entry, based on UFS|eMMC device.
-/dev/block/bootdevice/by-name/userdata                            /data                f2fs    noatime,nosuid,nodev,discard,reserve_root=32768,resgid=1065,fsync_mode=nobarrier,inlinecrypt    latemount,wait,check,formattable,encryptable=ice,wrappedkey,quota,reservedsize=128M,checkpoint=fs
+/dev/block/bootdevice/by-name/userdata                            /data                f2fs    noatime,nosuid,nodev,discard,reserve_root=32768,resgid=1065,fsync_mode=nobarrier,inlinecrypt    latemount,wait,check,formattable,fileencryption=ice,wrappedkey,quota,reservedsize=128M,checkpoint=fs
 /devices/platform/soc/8804000.sdhci/mmc_host*                     /storage/sdcard1     vfat    nosuid,nodev                                                                                    wait,voldmanaged=sdcard1:auto,encryptable=footer
 /devices/platform/soc/1da4000.ufshc_card/host*                    /storage/sdcard1     vfat    nosuid,nodev                                                                                    wait,voldmanaged=sdcard1:auto,encryptable=footer
 /dev/block/bootdevice/by-name/modem                               /vendor/firmware_mnt vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0    wait


### PR DESCRIPTION
* some users want encrypted builds and some others want decrypted ones
* which puts me in a weird situation.
* So I decided to ship Vanilla Builds Encrypted and GApp Builds decrypted
* Also Reverts 1d19c67e3f94d3ca5b07335e2d5c48cded97ac11

Signed-off-by: AtlanPrime <zilliondollarkuruvi@gmail.com>