### PR TITLE
surya: Hide Magisk Better

### DIFF
--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -171,3 +171,9 @@ service vendor.remosaic_daemon /vendor/bin/remosaic_daemon
     user camera
     group camera
     writepid /dev/cpuset/system-background/tasks
+	
+
+# Restrict permissions to socket file
+# to hide Magisk & co.
+    chmod 440 /proc/net/unix	
+	


### PR DESCRIPTION
* Some banking apps read the file /proc/net/unix to
find out whether things like Magisk are installed/running.

To prevent that, chmod it 440.
This file isn't needed by any other process when boot is finished.

I've tested this and banking apps that did not work before
and recognized Magisk being installed now don't recognize
that and work just fine.

Signed-off-by: AtlanPrime <zilliondollarkuruvi@gmail.com>